### PR TITLE
Add a min example for NGINX Plus

### DIFF
--- a/examples/deployment-oss-min/README.md
+++ b/examples/deployment-oss-min/README.md
@@ -13,10 +13,12 @@ Have the NGINX Ingress Operator deployed in your cluster. Follow [installation](
     kubectl create -f ns.yaml
     ```  
 
-2. Create a new NginxIngressController resource that defines our NGINX Ingress Controller instance:
+2. Create a new NginxIngressController resource that defines our NGINX Ingress Controller instance (**Note**: If using Openshift, change the `image.tag` to `edge-ubi`):
     ```
     kubectl create -f nginx-ingress-controller.yaml
     ```
+
+ 
 
 This will deploy an NGINX Ingress Controller instance using a [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) in the `my-nginx-controller` namespace. 
 

--- a/examples/deployment-plus-min/README.md
+++ b/examples/deployment-plus-min/README.md
@@ -1,10 +1,13 @@
 # Example
 
-In this example we deploy the NGINX Ingress Controller (edge) as a [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) using the NGINX Ingress Operator for NGINX Open Source.
+In this example we deploy the NGINX Ingress Controller (edge) as a [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) using the NGINX Ingress Operator for NGINX Plus.
 
 ## Prerequisites
 
-Have the NGINX Ingress Operator deployed in your cluster. Follow [installation](../../README.md#installation) steps.
+1. Have the NGINX Ingress Operator deployed in your cluster. Follow [installation](../../README.md#installation) steps.
+2. Build the NGINX Ingress Controller for Plus image and push it to a private repository following [these instructions](https://docs.nginx.com/nginx-ingress-controller/installation/building-ingress-controller-image/#building-the-image-and-pushing-it-to-the-private-registry). 
+
+**Note**: For the build process, if using Openshift, use the `DOCKERFILE=openshift/DockerfileForPlus` variable. 
 
 ## Running the example
 
@@ -13,7 +16,7 @@ Have the NGINX Ingress Operator deployed in your cluster. Follow [installation](
     kubectl create -f ns.yaml
     ```  
 
-2. Create a new NginxIngressController resource that defines our NGINX Ingress Controller instance:
+2. Create a new NginxIngressController resource that defines our NGINX Ingress Controller instance (**Note:** Update the `image.repository` field in the `nginx-ingress-controller.yaml` with your previously built image for NGINX Plus):
     ```
     kubectl create -f nginx-ingress-controller.yaml
     ```

--- a/examples/deployment-plus-min/README.md
+++ b/examples/deployment-plus-min/README.md
@@ -5,9 +5,9 @@ In this example we deploy the NGINX Ingress Controller (edge) as a [Deployment](
 ## Prerequisites
 
 1. Have the NGINX Ingress Operator deployed in your cluster. Follow [installation](../../README.md#installation) steps.
-2. Build the NGINX Ingress Controller for Plus image and push it to a private repository following [these instructions](https://docs.nginx.com/nginx-ingress-controller/installation/building-ingress-controller-image/#building-the-image-and-pushing-it-to-the-private-registry). 
-
-**Note**: For the build process, if using Openshift, use the `DOCKERFILE=openshift/DockerfileForPlus` variable. 
+2. Build the NGINX Ingress Controller for Plus image and push it to a private repository following 
+[these instructions](https://docs.nginx.com/nginx-ingress-controller/installation/building-ingress-controller-image/#building-the-image-and-pushing-it-to-the-private-registry) 
+(**Note**: For the build process, if using Openshift, use the `DOCKERFILE=openshift/DockerfileForPlus` variable). 
 
 ## Running the example
 

--- a/examples/deployment-plus-min/nginx-ingress-controller.yaml
+++ b/examples/deployment-plus-min/nginx-ingress-controller.yaml
@@ -1,0 +1,17 @@
+apiVersion: k8s.nginx.org/v1alpha1
+kind: NginxIngressController
+metadata:
+  name: my-nginx-ingress-controller
+  namespace: my-nginx-ingress
+spec:
+  type: deployment
+  nginxPlus: true
+  image:
+    repository: nginx/nginx-ingress
+    tag: edge
+    pullPolicy: Always
+  replicas: 1
+  serviceType: NodePort
+  enableCRDs: true
+  nginxStatus:
+    enable: true

--- a/examples/deployment-plus-min/nginx-ingress-controller.yaml
+++ b/examples/deployment-plus-min/nginx-ingress-controller.yaml
@@ -7,7 +7,7 @@ spec:
   type: deployment
   nginxPlus: true
   image:
-    repository: nginx/nginx-ingress
+    repository: nginx-plus-ingress
     tag: edge
     pullPolicy: Always
   replicas: 1

--- a/examples/deployment-plus-min/ns.yaml
+++ b/examples/deployment-plus-min/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-nginx-ingress


### PR DESCRIPTION
### Proposed changes
These PR adds a min example to deploy the NGINX Ingress Controller for NGINX Plus using the operator.