### PR TITLE
Add new CRDs for KIC 1.7

### DIFF
--- a/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
+++ b/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
@@ -55,6 +55,15 @@ spec:
                 controller reporting the status of Ingress resources – only one replica
                 will report status.
               type: boolean
+            enableTLSPassthrough:
+              description: Enable TLS Passthrough on port 443. Requires enableCRDs
+                set to true.
+              type: boolean
+            globalConfiguration:
+              description: The GlobalConfiguration resource for global configuration
+                of the Ingress Controller. Format is namespace/name. Requires enableCRDs
+                set to true.
+              type: string
             healthStatus:
               description: Adds a new location to the default server. The location
                 responds with the 200 status code for any request. Useful for external
@@ -123,7 +132,7 @@ spec:
                     commas. (default “127.0.0.1”)
                   type: string
                 enable:
-                  description: Enable the NginxStatus. Default is true.
+                  description: Enable the NginxStatus.
                   type: boolean
                 port:
                   description: Set the port where the NGINX stub_status or the NGINX
@@ -152,7 +161,7 @@ spec:
               type: object
             replicas:
               description: The number of replicas of the Ingress Controller pod. The
-                default is 1. Only applies if the Kind is set to deployment.
+                default is 1. Only applies if the type is set to deployment.
               format: int32
               type: integer
             reportIngressStatus:

--- a/docs/nginx-ingress-controller.md
+++ b/docs/nginx-ingress-controller.md
@@ -65,6 +65,8 @@ spec:
      port: 9114
    configMapData:
      error-log-level: debug
+   enableTLSPassthrough: true
+   globalConfiguration: my-nginx-ingress/nginx-configuration
  ``` 
  
 | Field | Type | Description | Required |
@@ -88,7 +90,9 @@ spec:
 | `wildcardTLS` | `string` | A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified. If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection. If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress Controller will fail to start. Format is `namespace/name`. | No |
 | `prometheus` | [prometheus](#nginxingresscontrollerprometheus) | Configures NGINX or NGINX Plus metrics in the Prometheus format. | No |
 | `configMapData` | `map[string]string` | Initial values of the Ingress Controller ConfigMap. Check the [ConfigMap docs](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource/) for more information about possible values. | No |
- 
+| `globalConfiguration` | `string` | The GlobalConfiguration resource for global configuration of the Ingress Controller. Format is namespace/name. Requires enableCRDs set to true. | No | 
+| `enableTLSPassthrough` | `boolean` | Enable TLS Passthrough on port 443. Requires enableCRDs set to true. | No | 
+
 ## NginxIngressController.Image
 
 | Field | Type | Description | Required |

--- a/examples/deployment-oss-min/nginx-ingress-controller.yaml
+++ b/examples/deployment-oss-min/nginx-ingress-controller.yaml
@@ -9,9 +9,7 @@ spec:
   image:
     repository: nginx/nginx-ingress
     tag: edge
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   replicas: 1
   serviceType: NodePort
   enableCRDs: true
-  nginxStatus:
-    enable: true

--- a/examples/deployment-plus-min/nginx-ingress-controller.yaml
+++ b/examples/deployment-plus-min/nginx-ingress-controller.yaml
@@ -9,9 +9,7 @@ spec:
   image:
     repository: nginx-plus-ingress
     tag: edge
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   replicas: 1
   serviceType: NodePort
   enableCRDs: true
-  nginxStatus:
-    enable: true

--- a/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
+++ b/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
@@ -80,6 +80,15 @@ type NginxIngressControllerSpec struct {
 	// +kubebuilder:validation:Optional
 	// +nullable
 	ConfigMapData map[string]string `json:"configMapData"`
+	// The GlobalConfiguration resource for global configuration of the Ingress Controller.
+	// Format is namespace/name.
+	// Requires enableCRDs set to true.
+	// +kubebuilder:validation:Optional
+	GlobalConfiguration string `json:"globalConfiguration"`
+	// Enable TLS Passthrough on port 443.
+	// Requires enableCRDs set to true.
+	// +kubebuilder:validation:Optional
+	EnableTLSPassthrough bool `json:"enableTLSPassthrough"`
 }
 
 // Image defines the Repository, Tag and ImagePullPolicy of the Ingress Controller Image.

--- a/pkg/controller/nginxingresscontroller/crds.go
+++ b/pkg/controller/nginxingresscontroller/crds.go
@@ -54,3 +54,53 @@ func vsrForNginxIngressController() *v1beta1.CustomResourceDefinition {
 		},
 	}
 }
+
+func gcForNginxIngressController() *v1beta1.CustomResourceDefinition {
+	return &v1beta1.CustomResourceDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "globalconfigurations.k8s.nginx.org",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group: "k8s.nginx.org",
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Plural:     "globalconfigurations",
+				Singular:   "globalconfiguration",
+				ShortNames: []string{"gc"},
+				Kind:       "GlobalConfiguration",
+			},
+			Scope: "Namespaced",
+			Versions: []v1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+	}
+}
+
+func tsForNginxIngressController() *v1beta1.CustomResourceDefinition {
+	return &v1beta1.CustomResourceDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "transportservers.k8s.nginx.org",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group: "k8s.nginx.org",
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Plural:     "transportservers",
+				Singular:   "transportserver",
+				ShortNames: []string{"ts"},
+				Kind:       "TransportServer",
+			},
+			Scope: "Namespaced",
+			Versions: []v1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/nginxingresscontroller/crds_test.go
+++ b/pkg/controller/nginxingresscontroller/crds_test.go
@@ -67,3 +67,63 @@ func TestVsrForNginxIngressController(t *testing.T) {
 		t.Errorf("vsrForNginxIngressController() returned %+v but expected %+v", result, expected)
 	}
 }
+
+func TestGcForNginxIngressController(t *testing.T) {
+	expected := &v1beta1.CustomResourceDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "globalconfigurations.k8s.nginx.org",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group: "k8s.nginx.org",
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Plural:     "globalconfigurations",
+				Singular:   "globalconfiguration",
+				ShortNames: []string{"gc"},
+				Kind:       "GlobalConfiguration",
+			},
+			Scope: "Namespaced",
+			Versions: []v1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+	}
+
+	result := gcForNginxIngressController()
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("gcForNginxIngressController() returned %+v but expected %+v", result, expected)
+	}
+}
+
+func TestTsForNginxIngressController(t *testing.T) {
+	expected := &v1beta1.CustomResourceDefinition{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "transportservers.k8s.nginx.org",
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group: "k8s.nginx.org",
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Plural:     "transportservers",
+				Singular:   "transportserver",
+				ShortNames: []string{"ts"},
+				Kind:       "TransportServer",
+			},
+			Scope: "Namespaced",
+			Versions: []v1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+	}
+
+	result := tsForNginxIngressController()
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("tsForNginxIngressController() returned %+v but expected %+v", result, expected)
+	}
+}

--- a/pkg/controller/nginxingresscontroller/rbac.go
+++ b/pkg/controller/nginxingresscontroller/rbac.go
@@ -45,7 +45,7 @@ func clusterRoleForNginxIngressController(name string) *rbacv1.ClusterRole {
 		{
 			Verbs:     []string{"get", "list", "watch"},
 			APIGroups: []string{"k8s.nginx.org"},
-			Resources: []string{"virtualservers", "virtualserverroutes"},
+			Resources: []string{"virtualservers", "virtualserverroutes", "globalconfigurations", "transportservers"},
 		},
 	}
 

--- a/pkg/controller/nginxingresscontroller/rbac_test.go
+++ b/pkg/controller/nginxingresscontroller/rbac_test.go
@@ -53,7 +53,7 @@ func TestClusterRoleForNginxIngressController(t *testing.T) {
 			{
 				Verbs:     []string{"get", "list", "watch"},
 				APIGroups: []string{"k8s.nginx.org"},
-				Resources: []string{"virtualservers", "virtualserverroutes"},
+				Resources: []string{"virtualservers", "virtualserverroutes", "globalconfigurations", "transportservers"},
 			},
 		},
 	}

--- a/pkg/controller/nginxingresscontroller/utils_test.go
+++ b/pkg/controller/nginxingresscontroller/utils_test.go
@@ -127,6 +127,25 @@ func TestGeneratePodArgs(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: k8sv1alpha1.NginxIngressControllerSpec{
+					EnableCRDs:           true,
+					EnableTLSPassthrough: true,
+					GlobalConfiguration:  "my-nginx-ingress/globalconfiguration",
+				},
+			},
+			expected: []string{
+				"-nginx-configmaps=my-nginx-ingress/my-nginx-ingress",
+				"-default-server-tls-secret=my-nginx-ingress/my-nginx-ingress",
+				"-enable-tls-passthrough",
+				"-global-configuration=my-nginx-ingress/globalconfiguration",
+			},
+		},
+		{
+			instance: &k8sv1alpha1.NginxIngressController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: k8sv1alpha1.NginxIngressControllerSpec{
 					NginxPlus:           true,
 					DefaultSecret:       "my-nginx-ingress/my-secret",
 					EnableCRDs:          false,
@@ -154,6 +173,8 @@ func TestGeneratePodArgs(t *testing.T) {
 						Enable: true,
 						Port:   9114,
 					},
+					GlobalConfiguration:  "my-nginx-ingress/globalconfiguration",
+					EnableTLSPassthrough: true,
 				},
 			},
 			expected: []string{


### PR DESCRIPTION
### Proposed changes
* Add the creation of the new CRDs for KIC (TransportServer and GlobalConfiguration)
* Add 2 new fields to the CR (enable passthrough and GlobalConfiguration)
* Fix a problem with SCC when not in Openshift (API returns an error in k8s, but that error should not be taken as a real error if the Resource definition doesn't exist. There is no specific check for this, so the only way we have right now to filter the error is with error msg)
* Make sure ClusterRole is updated when Operator runs for the first time. This is due to possible changes in the ClusterRole (For instance, adding new CRDs, like this example).


