### PR TITLE
Update makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-OLD_TAG = 0.0.3
 TAG = 0.0.4
+
 IMAGE = nginx-ingress-operator
 
 RUN_NAMESPACE = default
@@ -31,8 +31,7 @@ generate-bundle:
 	mkdir bundle
 	cp deploy/crds/* bundle/
 	cp deploy/olm-catalog/nginx-ingress-operator/nginx-ingress-operator.package.yaml bundle/
-	cp deploy/olm-catalog/nginx-ingress-operator/$(TAG)/* bundle/
-	cp deploy/olm-catalog/nginx-ingress-operator/$(OLD_TAG)/nginx-ingress-operator.v$(OLD_TAG).clusterserviceversion.yaml bundle/
+	./hack/copy_manifests.sh
 	-rm bundle.zip
 	zip -j bundle.zip bundle/*.yaml
 

--- a/hack/copy_manifests.sh
+++ b/hack/copy_manifests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for f in $(find deploy/olm-catalog -name "*clusterserviceversion.yaml"); do
+  cp $f bundle/
+done


### PR DESCRIPTION
### Proposed changes
Note: Merge this after release https://github.com/nginxinc/nginx-ingress-operator/pull/6

This is done because we were told only the previous version of the manifests needed to be uploaded for RH certification. It seems we need to upload all of them, so copying every yaml manifest in the bundle for the makefile.

As a result, OLD_TAG is not required anymore.