### PR TITLE
Add enableSnippets cli argument support

### DIFF
--- a/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
+++ b/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
@@ -55,6 +55,10 @@ spec:
                   the controller reporting the status of Ingress resources – only
                   one replica will report status.
                 type: boolean
+              enableSnippets:
+                description: Enable custom NGINX configuration snippets in VirtualServer
+                  and VirtualServerRoute resources. Requires enableCRDs set to true.
+                type: boolean
               enableTLSPassthrough:
                 description: Enable TLS Passthrough on port 443. Requires enableCRDs
                   set to true.

--- a/docs/nginx-ingress-controller.md
+++ b/docs/nginx-ingress-controller.md
@@ -42,6 +42,7 @@ spec:
    replicas: 3
    serviceType: NodePort
    enableCRDs: true
+   enableSnippets: false
    defaultSecret: my-nginx-ingress/default-secret
    ingressClass: my-nginx-ingress
    useIngressClassOnly: true
@@ -78,6 +79,7 @@ spec:
 | `defaultSecret` | `string` | The TLS Secret for TLS termination of the default server. The format is namespace/name. If not specified, the operator will generate and deploy a TLS Secret with a self-signed certificate and key. | No |
 | `serviceType` | `string` | The type of the Service for the Ingress Controller. Valid Service types are `NodePort` or `LoadBalancer`. | Yes |
 | `enableCRDs` | `boolean` | Enables the use of NGINX Ingress Resource Definitions (VirtualServer and VirtualServerRoute). | No |
+| `enableSnippets` | `boolean` | Enable custom NGINX configuration snippets in VirtualServer and VirtualServerRoute resources. Requires enableCRDs set to true. | No |
 | `ingressClass` | `string` | A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its class (in other words, have the annotation `kubernetes.io/ingress.class`. Additionally, the Ingress controller processes Ingress resources that do not have that annotation, which can be disabled by setting `useIngressClassOnly` to `true`. Default is `nginx`. | No |
 | `useIngressClassOnly` | `boolean` | Ignore Ingress resources without the `kubernetes.io/ingress.class` annotation. | No |
 | `watchNamespace` | `boolean` | Namespace to watch for Ingress resources. By default the Ingress controller watches all namespaces. | No |
@@ -90,8 +92,8 @@ spec:
 | `wildcardTLS` | `string` | A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified. If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection. If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress Controller will fail to start. Format is `namespace/name`. | No |
 | `prometheus` | [prometheus](#nginxingresscontrollerprometheus) | Configures NGINX or NGINX Plus metrics in the Prometheus format. | No |
 | `configMapData` | `map[string]string` | Initial values of the Ingress Controller ConfigMap. Check the [ConfigMap docs](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource/) for more information about possible values. | No |
-| `globalConfiguration` | `string` | The GlobalConfiguration resource for global configuration of the Ingress Controller. Format is namespace/name. Requires enableCRDs set to true. | No | 
-| `enableTLSPassthrough` | `boolean` | Enable TLS Passthrough on port 443. Requires enableCRDs set to true. | No | 
+| `globalConfiguration` | `string` | The GlobalConfiguration resource for global configuration of the Ingress Controller. Format is namespace/name. Requires enableCRDs set to true. | No |
+| `enableTLSPassthrough` | `boolean` | Enable TLS Passthrough on port 443. Requires enableCRDs set to true. | No |
 
 ## NginxIngressController.Image
 

--- a/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
+++ b/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
@@ -34,6 +34,10 @@ type NginxIngressControllerSpec struct {
 	// Enables the use of NGINX Ingress Resource Definitions (VirtualServer and VirtualServerRoute).
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	EnableCRDs bool `json:"enableCRDs"`
+	// Enable custom NGINX configuration snippets in VirtualServer and VirtualServerRoute resources.
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
+	EnableSnippets bool `json:"enableSnippets"`
 	// +kubebuilder:validation:Optional
 	// A class of the Ingress controller. The Ingress controller only processes Ingress resources that belong to its
 	// class (in other words, have the annotation “kubernetes.io/ingress.class”).

--- a/pkg/controller/nginxingresscontroller/utils.go
+++ b/pkg/controller/nginxingresscontroller/utils.go
@@ -109,6 +109,10 @@ func generatePodArgs(instance *k8sv1alpha1.NginxIngressController) []string {
 		if instance.Spec.GlobalConfiguration != "" {
 			args = append(args, fmt.Sprintf("-global-configuration=%v", instance.Spec.GlobalConfiguration))
 		}
+
+		if instance.Spec.EnableSnippets {
+			args = append(args, "-enable-snippets")
+		}
 	}
 
 	return args

--- a/pkg/controller/nginxingresscontroller/utils_test.go
+++ b/pkg/controller/nginxingresscontroller/utils_test.go
@@ -131,6 +131,7 @@ func TestGeneratePodArgs(t *testing.T) {
 				},
 				Spec: k8sv1alpha1.NginxIngressControllerSpec{
 					EnableCRDs:           true,
+					EnableSnippets:       true,
 					EnableTLSPassthrough: true,
 					GlobalConfiguration:  "my-nginx-ingress/globalconfiguration",
 				},
@@ -140,6 +141,7 @@ func TestGeneratePodArgs(t *testing.T) {
 				"-default-server-tls-secret=my-nginx-ingress/my-nginx-ingress",
 				"-enable-tls-passthrough",
 				"-global-configuration=my-nginx-ingress/globalconfiguration",
+				"-enable-snippets",
 			},
 		},
 		{
@@ -177,6 +179,7 @@ func TestGeneratePodArgs(t *testing.T) {
 						Port:   &promPort,
 					},
 					GlobalConfiguration:  "my-nginx-ingress/globalconfiguration",
+					EnableSnippets:       true,
 					EnableTLSPassthrough: true,
 				},
 			},


### PR DESCRIPTION
### Proposed changes
* Add support for the `enableSnippets` cli argument which was added in: https://github.com/nginxinc/kubernetes-ingress/pull/1019

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork