### PR TITLE
Update secret type of default secret to TLS

### DIFF
--- a/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
+++ b/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
@@ -53,9 +53,9 @@ spec:
               type: object
             defaultSecret:
               description: The TLS Secret for TLS termination of the default server.
-                The format is namespace/name. If not specified, the operator will
-                generate and deploy a TLS Secret with a self-signed certificate and
-                key.
+                The format is namespace/name. The secret must be of the type kubernetes.io/tls.
+                If not specified, the operator will generate and deploy a TLS Secret
+                with a self-signed certificate and key.
               type: string
             enableCRDs:
               description: Enables the use of NGINX Ingress Resource Definitions (VirtualServer
@@ -235,11 +235,11 @@ spec:
             wildcardTLS:
               description: A Secret with a TLS certificate and key for TLS termination
                 of every Ingress host for which TLS termination is enabled but the
-                Secret is not specified. If the argument is not set, for such Ingress
-                hosts NGINX will break any attempt to establish a TLS connection.
-                If the argument is set, but the Ingress controller is not able to
-                fetch the Secret from Kubernetes API, the Ingress Controller will
-                fail to start. Format is namespace/name.
+                Secret is not specified. The secret must be of the type kubernetes.io/tls.
+                If the argument is not set, for such Ingress hosts NGINX will break
+                any attempt to establish a TLS connection. If the argument is set,
+                but the Ingress controller is not able to fetch the Secret from Kubernetes
+                API, the Ingress Controller will fail to start. Format is namespace/name.
               type: string
           required:
           - enableCRDs

--- a/docs/nginx-ingress-controller.md
+++ b/docs/nginx-ingress-controller.md
@@ -80,7 +80,7 @@ spec:
 | `nginxPlus` | `boolean` | Deploys the Ingress Controller for NGINX Plus. The default is `false` meaning the Ingress Controller will be deployed for NGINX OSS. | No |
 | `image` | [image](#nginxingresscontrollerimage) | The image of the Ingress Controller. | Yes |
 | `replicas` | `int` | The number of replicas of the Ingress Controller pod. The default is 1. Only applies if the `type` is set to deployment. | No |
-| `defaultSecret` | `string` | The TLS Secret for TLS termination of the default server. The format is namespace/name. If not specified, the operator will generate and deploy a TLS Secret with a self-signed certificate and key. | No |
+| `defaultSecret` | `string` | The TLS Secret for TLS termination of the default server. The format is namespace/name. The secret must be of the type kubernetes.io/tls. If not specified, the operator will generate and deploy a TLS Secret with a self-signed certificate and key. | No |
 | `serviceType` | `string` | The type of the Service for the Ingress Controller. Valid Service types are `NodePort` or `LoadBalancer`. | Yes |
 | `enableCRDs` | `boolean` | Enables the use of NGINX Ingress Resource Definitions (VirtualServer and VirtualServerRoute). | No |
 | `enableSnippets` | `boolean` | Enable custom NGINX configuration snippets in VirtualServer and VirtualServerRoute resources. Requires enableCRDs set to true. | No |
@@ -93,7 +93,7 @@ spec:
 | `nginxStatus` | [nginxStatus](#nginxingresscontrollernginxstatus) | Configures NGINX stub_status, or the NGINX Plus API. | No |
 | `reportIngressStatus` | [reportIngressStatus](#nginxingresscontrollerreportingressstatus) | Update the address field in the status of Ingresses resources. | No |
 | `enableLeaderElection` | `boolean` | Enables Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources – only one replica will report status. | No |
-| `wildcardTLS` | `string` | A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified. If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection. If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress Controller will fail to start. Format is `namespace/name`. | No |
+| `wildcardTLS` | `string` | A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified. The secret must be of the type kubernetes.io/tls. If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection. If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress Controller will fail to start. Format is `namespace/name`. | No |
 | `prometheus` | [prometheus](#nginxingresscontrollerprometheus) | Configures NGINX or NGINX Plus metrics in the Prometheus format. | No |
 | `configMapData` | `map[string]string` | Initial values of the Ingress Controller ConfigMap. Check the [ConfigMap docs](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource/) for more information about possible values. | No |
 | `globalConfiguration` | `string` | The GlobalConfiguration resource for global configuration of the Ingress Controller. Format is namespace/name. Requires enableCRDs set to true. | No |

--- a/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
+++ b/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
@@ -23,6 +23,7 @@ type NginxIngressControllerSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Replicas *int32 `json:"replicas"`
 	// The TLS Secret for TLS termination of the default server. The format is namespace/name.
+	// The secret must be of the type kubernetes.io/tls.
 	// If not specified, the operator will generate and deploy a TLS Secret with a self-signed certificate and key.
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
@@ -87,6 +88,7 @@ type NginxIngressControllerSpec struct {
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	EnableLeaderElection bool `json:"enableLeaderElection"`
 	// A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified.
+	// The secret must be of the type kubernetes.io/tls.
 	// If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection.
 	// If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress Controller will fail to start.
 	// Format is namespace/name.

--- a/pkg/controller/nginxingresscontroller/secret.go
+++ b/pkg/controller/nginxingresscontroller/secret.go
@@ -30,10 +30,10 @@ func defaultSecretForNginxIngressController(instance *k8sv1alpha1.NginxIngressCo
 			Namespace: instance.Namespace,
 		},
 		Data: map[string][]byte{
-			"tls.crt": crt,
-			"tls.key": key,
+			corev1.TLSCertKey:       crt,
+			corev1.TLSPrivateKeyKey: key,
 		},
-		Type: "Opaque",
+		Type: corev1.SecretTypeTLS,
 	}
 
 	return secret, nil

--- a/pkg/controller/nginxingresscontroller/secret_test.go
+++ b/pkg/controller/nginxingresscontroller/secret_test.go
@@ -1,0 +1,43 @@
+package nginxingresscontroller
+
+import (
+	"reflect"
+	"testing"
+
+	k8sv1alpha1 "github.com/nginxinc/nginx-ingress-operator/pkg/apis/k8s/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDefaultSecretForNginxIngressController(t *testing.T) {
+	instance := &k8sv1alpha1.NginxIngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-nginx-ingress-controller",
+			Namespace: "my-nginx-ingress-controller-ns",
+		},
+	}
+
+	expectedObjectMeta := &metav1.ObjectMeta{
+		Name:      "my-nginx-ingress-controller",
+		Namespace: "my-nginx-ingress-controller-ns",
+	}
+	expectedType := corev1.SecretTypeTLS
+
+	secret, err := defaultSecretForNginxIngressController(instance)
+	if err != nil {
+		t.Fatalf("defaultSecretForNginxIngressController() returned unexpected error %v", err)
+	}
+
+	if reflect.DeepEqual(expectedObjectMeta, secret.ObjectMeta) {
+		t.Errorf("defaultSecretForNginxIngressController() returned %v but expected %v", secret.ObjectMeta, expectedObjectMeta)
+	}
+	if expectedType != secret.Type {
+		t.Errorf("defaultSecretForNginxIngressController() returned %s but expected %s", secret.Type, expectedType)
+	}
+	if len(secret.Data[corev1.TLSCertKey]) == 0 {
+		t.Errorf("defaultSecretForNginxIngressController() returned empty data key %s", corev1.TLSCertKey)
+	}
+	if len(secret.Data[corev1.TLSPrivateKeyKey]) == 0 {
+		t.Errorf("defaultSecretForNginxIngressController() returned empty data key %s", corev1.TLSPrivateKeyKey)
+	}
+}


### PR DESCRIPTION
### Proposed changes
Update secret type of default secret to TLS

### Upgrade nodes

the following upgrade notes will need to be added to the CHANGELOG/release notes.

To upgrade the NGINX Ingress Controller from versions 1.9.* to 1.10.0, perform the following prerequisite steps. The steps are necessary, as version 1.10.0 requires TLS secrets to be of the type `kubernetes.io/tls`.

1. If the existing NginxIngressController resource does not set `defaultSecret` field:
    1. Remove the generated  default secret from the namespace of the  NginxIngressController resource. The secret has the same name as the NginxIngressController resource. For example:
        ```
        $ kubectl delete secret -n my-nginx-ingress my-nginx-ingress-controller
        ```
    1. Wait until the operator regenerates the secret. The old secret was of the type `Opaque`. The new secret is of the type `kubernetes.io/tls`.
1. Alternatively, if the `defaultSecret` is set to some secret, make sure it is of the type `kubernetes.io/tls`. If not, recreate the secret with the type `kubernetes.io/tls`.
1. If the `wildcardTLS` is set to some secret, make sure it is of the type `kubernetes.io/tls`. If not, recreate the secret with the type `kubernetes.io/tls`.
1. Ensure that the TLS secrets referenced by Ingress and VirtualServer resources are of the type `kubernetes.io/tls`, JWT secrets are of the type `nginx.org/jwt` and CA secrets are of the type `nginx.org/ca`. To avoid potential disruption of client traffic, instead of recreating the secrets, create new secrets with the correct type and update the Ingress/VirtualServer resources to use the new secrets.

After performing the steps above, upgrade the Ingress Controller to version 1.10.0.