### PR TITLE
Fix SCC resource to only affect KIC pods

### DIFF
--- a/pkg/controller/nginxingresscontroller/scc.go
+++ b/pkg/controller/nginxingresscontroller/scc.go
@@ -33,7 +33,6 @@ func sccForNginxIngressController(name string) *secv1.SecurityContextConstraints
 		FSGroup: secv1.FSGroupStrategyOptions{
 			Type: "MustRunAs",
 		},
-		Groups: []string{"system:authenticated"},
 		SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
 			Type: "MustRunAs",
 		},
@@ -48,5 +47,5 @@ func sccForNginxIngressController(name string) *secv1.SecurityContextConstraints
 }
 
 func userForSCC(namespace string, name string) string {
-	return fmt.Sprintf("%v:%v", namespace, name)
+	return fmt.Sprintf("system:serviceaccount:%v:%v", namespace, name)
 }

--- a/pkg/controller/nginxingresscontroller/scc.go
+++ b/pkg/controller/nginxingresscontroller/scc.go
@@ -9,7 +9,6 @@ import (
 )
 
 func sccForNginxIngressController(name string) *secv1.SecurityContextConstraints {
-	var priority int32 = 20
 	var uid int64 = 101
 
 	allowPrivilegeEscalation := true
@@ -19,7 +18,6 @@ func sccForNginxIngressController(name string) *secv1.SecurityContextConstraints
 			Name: name,
 		},
 		AllowHostPorts:           false,
-		Priority:                 &priority,
 		AllowPrivilegedContainer: false,
 		RunAsUser: secv1.RunAsUserStrategyOptions{
 			Type: "MustRunAs",

--- a/pkg/controller/nginxingresscontroller/scc_test.go
+++ b/pkg/controller/nginxingresscontroller/scc_test.go
@@ -2,9 +2,9 @@ package nginxingresscontroller
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	secv1 "github.com/openshift/api/security/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,7 +12,6 @@ import (
 
 func TestSccForNginxIngressController(t *testing.T) {
 	var uid int64 = 101
-
 	name := "my-nginx-ingress"
 	allowPrivilegeEscalation := true
 
@@ -50,8 +49,8 @@ func TestSccForNginxIngressController(t *testing.T) {
 	}
 
 	result := sccForNginxIngressController(name)
-	if !reflect.DeepEqual(result, expected) {
-		t.Errorf("sccForNginxIngressController(%v) returned %+v but expected %+v", name, result, expected)
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("sccForNginxIngressController() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/pkg/controller/nginxingresscontroller/scc_test.go
+++ b/pkg/controller/nginxingresscontroller/scc_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestSccForNginxIngressController(t *testing.T) {
-	var priority int32 = 20
 	var uid int64 = 101
 
 	name := "my-nginx-ingress"
@@ -22,7 +21,6 @@ func TestSccForNginxIngressController(t *testing.T) {
 			Name: name,
 		},
 		AllowHostPorts:           false,
-		Priority:                 &priority,
 		AllowPrivilegedContainer: false,
 		RunAsUser: secv1.RunAsUserStrategyOptions{
 			Type: "MustRunAs",

--- a/pkg/controller/nginxingresscontroller/scc_test.go
+++ b/pkg/controller/nginxingresscontroller/scc_test.go
@@ -35,7 +35,6 @@ func TestSccForNginxIngressController(t *testing.T) {
 		FSGroup: secv1.FSGroupStrategyOptions{
 			Type: "MustRunAs",
 		},
-		Groups: []string{"system:authenticated"},
 		SupplementalGroups: secv1.SupplementalGroupsStrategyOptions{
 			Type: "MustRunAs",
 		},
@@ -57,7 +56,7 @@ func TestSccForNginxIngressController(t *testing.T) {
 func TestUserForSCC(t *testing.T) {
 	namespace := "my-nginx-ingress"
 	name := "my-nginx-ingress-controller"
-	expected := fmt.Sprintf("%v:%v", namespace, name)
+	expected := fmt.Sprintf("system:serviceaccount:%v:%v", namespace, name)
 
 	result := userForSCC(namespace, name)
 	if expected != result {


### PR DESCRIPTION
Fixes: https://github.com/nginxinc/nginx-ingress-operator/issues/27

### Bug
More details in: https://github.com/nginxinc/nginx-ingress-operator/issues/27

If a pod is created is the same namespace it binds to the operators SCC and tries to use the `nginx` user which is unavailable.

### Proposed changes
Priority of 20 overrides the max priority of the default: AnyPid. This
leads to the SCC binding to all pods created in the same namespace
rather than just KIC pods.

Priority is now changed to the default value so if a new pod is created,
it takes the default SCC rather than the SCC of the operator.

#### Before fix
```
$ oc get pod -n my-nginx-ingress my-nginx-ingress-controller-7bcb66bd76-4h4pl -o template='{{index .metadata.annotations "openshift.io/scc"}}'
nginx-ingress-scc%

$ oc run nginx -n my-nginx-ingress --image=nginx --restart=Never -- sleep 3600
pod/nginx created

$ oc get pod -n my-nginx-ingress nginx4 -o template='{{index .metadata.annotations "openshift.io/scc"}}'
nginx-ingress-scc%
```

#### After fix
```
$ oc get pod -n my-nginx-ingress my-nginx-ingress-controller-7bcb66bd76-4h4pl -o template='{{index .metadata.annotations "openshift.io/scc"}}'
nginx-ingress-scc%

$ oc run nginx -n my-nginx-ingress --image=nginx --restart=Never -- sleep 3600
pod/nginx created

$ oc get pod -n my-nginx-ingress nginx -o template='{{index .metadata.annotations "openshift.io/scc"}}'
anyuid%
```

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork