### PR TITLE
Fix Service to be an optional field. Add support for updating ExtraLabels.

### DIFF
--- a/pkg/controller/nginxingresscontroller/service.go
+++ b/pkg/controller/nginxingresscontroller/service.go
@@ -8,11 +8,16 @@ import (
 )
 
 func serviceForNginxIngressController(instance *k8sv1alpha1.NginxIngressController) *corev1.Service {
+	extraLabels := map[string]string{}
+	if instance.Spec.Service != nil {
+		extraLabels = instance.Spec.Service.ExtraLabels
+	}
+
 	return &corev1.Service{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
-			Labels:    instance.Spec.Service.ExtraLabels,
+			Labels:    extraLabels,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{

--- a/pkg/controller/nginxingresscontroller/service.go
+++ b/pkg/controller/nginxingresscontroller/service.go
@@ -1,6 +1,8 @@
 package nginxingresscontroller
 
 import (
+	"reflect"
+
 	k8sv1alpha1 "github.com/nginxinc/nginx-ingress-operator/pkg/apis/k8s/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,10 +49,21 @@ func serviceForNginxIngressController(instance *k8sv1alpha1.NginxIngressControll
 }
 
 func hasServiceChanged(svc *corev1.Service, instance *k8sv1alpha1.NginxIngressController) bool {
-	return svc.Spec.Type != corev1.ServiceType(instance.Spec.ServiceType)
+	if svc.Spec.Type != corev1.ServiceType(instance.Spec.ServiceType) {
+		return true
+	}
+	if instance.Spec.Service != nil && !reflect.DeepEqual(svc.Labels, instance.Spec.Service.ExtraLabels) {
+		return true
+	}
+	return svc.Labels != nil && instance.Spec.Service == nil
 }
 
 func updateService(svc *corev1.Service, instance *k8sv1alpha1.NginxIngressController) *corev1.Service {
 	svc.Spec.Type = corev1.ServiceType(instance.Spec.ServiceType)
+	if instance.Spec.Service != nil {
+		svc.Labels = instance.Spec.Service.ExtraLabels
+	} else {
+		svc.Labels = nil
+	}
 	return svc
 }

--- a/pkg/controller/nginxingresscontroller/service_test.go
+++ b/pkg/controller/nginxingresscontroller/service_test.go
@@ -13,7 +13,6 @@ import (
 func TestServiceForNginxIngressController(t *testing.T) {
 	name := "my-service"
 	namespace := "my-nginx-ingress"
-	serviceType := "LoadBalancer"
 	extraLabels := map[string]string{"app": "my-nginx-ingress"}
 
 	instance := &k8sv1alpha1.NginxIngressController{
@@ -23,7 +22,7 @@ func TestServiceForNginxIngressController(t *testing.T) {
 			Labels:    extraLabels,
 		},
 		Spec: k8sv1alpha1.NginxIngressControllerSpec{
-			ServiceType: serviceType,
+			ServiceType: string(corev1.ServiceTypeLoadBalancer),
 			Service: &k8sv1alpha1.Service{
 				ExtraLabels: extraLabels,
 			},
@@ -57,12 +56,267 @@ func TestServiceForNginxIngressController(t *testing.T) {
 				},
 			},
 			Selector: map[string]string{"app": instance.Name},
-			Type:     corev1.ServiceType(serviceType),
+			Type:     corev1.ServiceTypeLoadBalancer,
 		},
 	}
 
 	result := serviceForNginxIngressController(instance)
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("serviceForNginxIngressController() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestHasServiceChanged(t *testing.T) {
+	name := "my-service"
+	namespace := "my-nginx-ingress"
+	extraLabels := map[string]string{"app": "my-nginx-ingress"}
+
+	tests := []struct {
+		svc      *corev1.Service
+		instance *k8sv1alpha1.NginxIngressController
+		expected bool
+		msg      string
+	}{
+		{
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			&k8sv1alpha1.NginxIngressController{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: k8sv1alpha1.NginxIngressControllerSpec{
+					ServiceType: string(corev1.ServiceTypeLoadBalancer),
+				},
+			},
+			false,
+			"no changes",
+		},
+		{
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			&k8sv1alpha1.NginxIngressController{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: k8sv1alpha1.NginxIngressControllerSpec{
+					ServiceType: "NodePort",
+				},
+			},
+			true,
+			"different service type",
+		},
+		{
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels:    extraLabels,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			&k8sv1alpha1.NginxIngressController{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: k8sv1alpha1.NginxIngressControllerSpec{
+					ServiceType: string(corev1.ServiceTypeLoadBalancer),
+					Service: &k8sv1alpha1.Service{
+						ExtraLabels: map[string]string{"new": "label"},
+					},
+				},
+			},
+			true,
+			"different label",
+		},
+		{
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels:    extraLabels,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			&k8sv1alpha1.NginxIngressController{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: k8sv1alpha1.NginxIngressControllerSpec{
+					ServiceType: string(corev1.ServiceTypeLoadBalancer),
+					Service: &k8sv1alpha1.Service{
+						ExtraLabels: nil,
+					},
+				},
+			},
+			true,
+			"remove label",
+		},
+		{
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels:    extraLabels,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			&k8sv1alpha1.NginxIngressController{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: k8sv1alpha1.NginxIngressControllerSpec{
+					ServiceType: string(corev1.ServiceTypeLoadBalancer),
+				},
+			},
+			true,
+			"remove service parameters",
+		},
+	}
+	for _, test := range tests {
+		result := hasServiceChanged(test.svc, test.instance)
+		if result != test.expected {
+			t.Errorf("hasServiceChanged() = %v, want %v for the case of %v", result, test.expected, test.msg)
+		}
+	}
+}
+
+func TestUpdateService(t *testing.T) {
+	name := "my-service"
+	namespace := "my-nginx-ingress"
+	extraLabels := map[string]string{"app": "my-nginx-ingress"}
+
+	tests := []struct {
+		svc      *corev1.Service
+		instance *k8sv1alpha1.NginxIngressController
+		expected *corev1.Service
+		msg      string
+	}{
+		{
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			&k8sv1alpha1.NginxIngressController{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: k8sv1alpha1.NginxIngressControllerSpec{
+					ServiceType: string(corev1.ServiceTypeNodePort),
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+				},
+			},
+			"override service type",
+		},
+		{
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels:    map[string]string{"my": "labelToBeOverridden"},
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			&k8sv1alpha1.NginxIngressController{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: k8sv1alpha1.NginxIngressControllerSpec{
+					ServiceType: string(corev1.ServiceTypeLoadBalancer),
+					Service: &k8sv1alpha1.Service{
+						ExtraLabels: extraLabels,
+					},
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels:    extraLabels,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			"override labels",
+		},
+		{
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Labels:    map[string]string{"my": "labelToBeRemoved"},
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			&k8sv1alpha1.NginxIngressController{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: k8sv1alpha1.NginxIngressControllerSpec{
+					ServiceType: string(corev1.ServiceTypeLoadBalancer),
+				},
+			},
+			&corev1.Service{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			"remove labels",
+		},
+	}
+	for _, test := range tests {
+		result := updateService(test.svc, test.instance)
+		if diff := cmp.Diff(test.expected, result); diff != "" {
+			t.Errorf("updateService() mismatch for the case of %v (-want +got):\n%s", test.msg, diff)
+		}
 	}
 }


### PR DESCRIPTION
### Proposed changes
* In https://github.com/nginxinc/nginx-ingress-operator/pull/58 an optional field called `Service` was added, but the generation of any KIC service depended on it existing, added a nil check to prevent panics: https://github.com/nginxinc/nginx-ingress-operator/commit/ad81ccf7ba5816da4e384e58ef9fba4c2ea9f6df
* In https://github.com/nginxinc/nginx-ingress-operator/pull/58 I added support for adding extraLabels, however I missed the case of updating an already existing service. That is added in: https://github.com/nginxinc/nginx-ingress-operator/commit/38152435eee6d20f4240741d70da8541de28c73e

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork