### PR TITLE
Fix replicas and service to be optional fields

### DIFF
--- a/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
+++ b/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
@@ -195,6 +195,7 @@ spec:
               description: The number of replicas of the Ingress Controller pod. The
                 default is 1. Only applies if the type is set to deployment.
               format: int32
+              nullable: true
               type: integer
             reportIngressStatus:
               description: Update the address field in the status of Ingresses resources.
@@ -222,6 +223,7 @@ spec:
               type: object
             service:
               description: The service of the Ingress controller.
+              nullable: true
               properties:
                 extraLabels:
                   additionalProperties:

--- a/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
+++ b/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
@@ -20,6 +20,7 @@ type NginxIngressControllerSpec struct {
 	Image Image `json:"image"`
 	// The number of replicas of the Ingress Controller pod. The default is 1. Only applies if the type is set to deployment.
 	// +kubebuilder:validation:Optional
+	// +nullable
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Replicas *int32 `json:"replicas"`
 	// The TLS Secret for TLS termination of the default server. The format is namespace/name.
@@ -55,6 +56,7 @@ type NginxIngressControllerSpec struct {
 	IngressClass string `json:"ingressClass"`
 	// The service of the Ingress controller.
 	// +kubebuilder:validation:Optional
+	// +nullable
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	Service *Service `json:"service"`
 	// Ignore Ingress resources without the “kubernetes.io/ingress.class” annotation.

--- a/pkg/controller/nginxingresscontroller/deployment.go
+++ b/pkg/controller/nginxingresscontroller/deployment.go
@@ -82,7 +82,9 @@ func deploymentForNginxIngressController(instance *k8sv1alpha1.NginxIngressContr
 }
 
 func hasDeploymentChanged(dep *appsv1.Deployment, instance *k8sv1alpha1.NginxIngressController) bool {
-	if dep.Spec.Replicas != nil && instance.Spec.Replicas != nil && *dep.Spec.Replicas != *instance.Spec.Replicas {
+	defaultReplicaCount := int32(1)
+	if dep.Spec.Replicas != nil && instance.Spec.Replicas == nil && *dep.Spec.Replicas != defaultReplicaCount ||
+		dep.Spec.Replicas != nil && instance.Spec.Replicas != nil && *dep.Spec.Replicas != *instance.Spec.Replicas {
 		return true
 	}
 
@@ -101,6 +103,11 @@ func hasDeploymentChanged(dep *appsv1.Deployment, instance *k8sv1alpha1.NginxIng
 
 func updateDeployment(dep *appsv1.Deployment, instance *k8sv1alpha1.NginxIngressController) *appsv1.Deployment {
 	dep.Spec.Replicas = instance.Spec.Replicas
+	if instance.Spec.Replicas == nil {
+		defaultReplicaCount := new(int32)
+		*defaultReplicaCount = 1
+		dep.Spec.Replicas = defaultReplicaCount
+	}
 	dep.Spec.Template.Spec.Containers[0].Image = generateImage(instance.Spec.Image.Repository, instance.Spec.Image.Tag)
 	dep.Spec.Template.Spec.Containers[0].Args = generatePodArgs(instance)
 	return dep


### PR DESCRIPTION
Fixes: https://github.com/nginxinc/nginx-ingress-operator/issues/69

### Proposed changes
* Make service and replicas optional.
* Add default of `1` for replicas when not set.
* Make service nullable to allow a replicas be set to `0`.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork