### PR TITLE
Fix RBAC to be able to watch for AppProtect UDS changes

### DIFF
--- a/pkg/controller/nginxingresscontroller/rbac.go
+++ b/pkg/controller/nginxingresscontroller/rbac.go
@@ -60,7 +60,7 @@ func clusterRoleForNginxIngressController(name string) *rbacv1.ClusterRole {
 		{
 			Verbs:     []string{"get", "list", "watch"},
 			APIGroups: []string{"appprotect.f5.com"},
-			Resources: []string{"aplogconfs", "appolicies"},
+			Resources: []string{"aplogconfs", "appolicies", "apusersigs"},
 		},
 	}
 	return &rbacv1.ClusterRole{

--- a/pkg/controller/nginxingresscontroller/rbac_test.go
+++ b/pkg/controller/nginxingresscontroller/rbac_test.go
@@ -68,7 +68,7 @@ func TestClusterRoleForNginxIngressController(t *testing.T) {
 			{
 				Verbs:     []string{"get", "list", "watch"},
 				APIGroups: []string{"appprotect.f5.com"},
-				Resources: []string{"aplogconfs", "appolicies"},
+				Resources: []string{"aplogconfs", "appolicies", "apusersigs"},
 			},
 		},
 	}


### PR DESCRIPTION
### Proposed changes
* RBAC created by operator was missing permission to watch for User Defined Signature updates.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork