### PR TITLE
Fix enableCRDs default to be true

### DIFF
--- a/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
+++ b/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
@@ -60,6 +60,7 @@ spec:
             enableCRDs:
               description: Enables the use of NGINX Ingress Resource Definitions (VirtualServer
                 and VirtualServerRoute). Default is true.
+              nullable: true
               type: boolean
             enableLatencyMetrics:
               description: Bucketed response times from when NGINX establishes a connection

--- a/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
+++ b/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
@@ -35,8 +35,9 @@ type NginxIngressControllerSpec struct {
 	ServiceType string `json:"serviceType"`
 	// Enables the use of NGINX Ingress Resource Definitions (VirtualServer and VirtualServerRoute). Default is true.
 	// +kubebuilder:validation:Optional
+	// +nullable
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
-	EnableCRDs bool `json:"enableCRDs"`
+	EnableCRDs *bool `json:"enableCRDs"`
 	// Enable custom NGINX configuration snippets in VirtualServer and VirtualServerRoute resources.
 	// Requires enableCRDs set to true.
 	// +kubebuilder:validation:Optional

--- a/pkg/apis/k8s/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/k8s/v1alpha1/zz_generated.deepcopy.go
@@ -126,6 +126,11 @@ func (in *NginxIngressControllerSpec) DeepCopyInto(out *NginxIngressControllerSp
 		*out = new(int32)
 		**out = **in
 	}
+	if in.EnableCRDs != nil {
+		in, out := &in.EnableCRDs, &out.EnableCRDs
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service
 		*out = new(Service)

--- a/pkg/controller/nginxingresscontroller/utils.go
+++ b/pkg/controller/nginxingresscontroller/utils.go
@@ -40,10 +40,6 @@ func generatePodArgs(instance *k8sv1alpha1.NginxIngressController) []string {
 		}
 	}
 
-	if !instance.Spec.EnableCRDs {
-		args = append(args, "-enable-custom-resources=false")
-	}
-
 	if instance.Spec.IngressClass != "" {
 		args = append(args, fmt.Sprintf("-ingress-class=%v", instance.Spec.IngressClass))
 	}
@@ -115,7 +111,9 @@ func generatePodArgs(instance *k8sv1alpha1.NginxIngressController) []string {
 		}
 	}
 
-	if instance.Spec.EnableCRDs {
+	if instance.Spec.EnableCRDs != nil && !*instance.Spec.EnableCRDs {
+		args = append(args, "-enable-custom-resources=false")
+	} else {
 		if instance.Spec.EnableTLSPassthrough {
 			args = append(args, "-enable-tls-passthrough")
 		}

--- a/pkg/controller/nginxingresscontroller/utils_test.go
+++ b/pkg/controller/nginxingresscontroller/utils_test.go
@@ -17,6 +17,8 @@ func TestGeneratePodArgs(t *testing.T) {
 	statusPort = 9090
 	name := "my-nginx-ingress"
 	namespace := "my-nginx-ingress"
+	enableCRDs := true
+	disableCRDs := false
 	tests := []struct {
 		instance *k8sv1alpha1.NginxIngressController
 		expected []string
@@ -27,9 +29,7 @@ func TestGeneratePodArgs(t *testing.T) {
 					Name:      name,
 					Namespace: namespace,
 				},
-				Spec: k8sv1alpha1.NginxIngressControllerSpec{
-					EnableCRDs: true,
-				},
+				Spec: k8sv1alpha1.NginxIngressControllerSpec{},
 			},
 			expected: []string{
 				"-nginx-configmaps=my-nginx-ingress/my-nginx-ingress",
@@ -44,7 +44,6 @@ func TestGeneratePodArgs(t *testing.T) {
 				},
 				Spec: k8sv1alpha1.NginxIngressControllerSpec{
 					DefaultSecret: "my-nginx-ingress/my-secret",
-					EnableCRDs:    true,
 				},
 			},
 			expected: []string{
@@ -59,8 +58,7 @@ func TestGeneratePodArgs(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: k8sv1alpha1.NginxIngressControllerSpec{
-					NginxPlus:  true,
-					EnableCRDs: true,
+					NginxPlus: true,
 				},
 			},
 			expected: []string{
@@ -76,7 +74,7 @@ func TestGeneratePodArgs(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: k8sv1alpha1.NginxIngressControllerSpec{
-					EnableCRDs: false,
+					EnableCRDs: &disableCRDs,
 				},
 			},
 			expected: []string{
@@ -93,7 +91,7 @@ func TestGeneratePodArgs(t *testing.T) {
 				},
 				Spec: k8sv1alpha1.NginxIngressControllerSpec{
 					NginxPlus:     true,
-					EnableCRDs:    false,
+					EnableCRDs:    &disableCRDs,
 					DefaultSecret: "my-nginx-ingress/my-secret",
 				},
 			},
@@ -122,7 +120,6 @@ func TestGeneratePodArgs(t *testing.T) {
 			expected: []string{
 				"-nginx-configmaps=my-nginx-ingress/my-nginx-ingress",
 				"-default-server-tls-secret=my-nginx-ingress/my-secret",
-				"-enable-custom-resources=false",
 				"-report-ingress-status",
 				"-ingresslink=my-ingresslink",
 			},
@@ -145,7 +142,6 @@ func TestGeneratePodArgs(t *testing.T) {
 			expected: []string{
 				"-nginx-configmaps=my-nginx-ingress/my-nginx-ingress",
 				"-default-server-tls-secret=my-nginx-ingress/my-secret",
-				"-enable-custom-resources=false",
 				"-report-ingress-status",
 				fmt.Sprintf("-external-service=%v", name),
 			},
@@ -157,7 +153,7 @@ func TestGeneratePodArgs(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: k8sv1alpha1.NginxIngressControllerSpec{
-					EnableCRDs:            true,
+					EnableCRDs:            &enableCRDs,
 					EnableSnippets:        true,
 					EnablePreviewPolicies: true,
 					EnableTLSPassthrough:  true,
@@ -214,7 +210,7 @@ func TestGeneratePodArgs(t *testing.T) {
 						Enable: true,
 					},
 					NginxReloadTimeout:    5000,
-					EnableCRDs:            false,
+					EnableCRDs:            &disableCRDs,
 					EnableSnippets:        true,
 					EnablePreviewPolicies: true,
 				},
@@ -224,7 +220,6 @@ func TestGeneratePodArgs(t *testing.T) {
 				"-default-server-tls-secret=my-nginx-ingress/my-secret",
 				"-nginx-plus",
 				"-enable-app-protect",
-				"-enable-custom-resources=false",
 				"-ingress-class=ingressClass",
 				"-use-ingress-class-only",
 				"-watch-namespace=default",
@@ -242,6 +237,7 @@ func TestGeneratePodArgs(t *testing.T) {
 				"-enable-prometheus-metrics",
 				"-prometheus-metrics-listen-port=9114",
 				"-enable-latency-metrics",
+				"-enable-custom-resources=false",
 				"-nginx-reload-timeout=5000",
 			},
 		},
@@ -277,8 +273,7 @@ func TestHasDifferentArguments(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: k8sv1alpha1.NginxIngressControllerSpec{
-					NginxPlus:  true,
-					EnableCRDs: true,
+					NginxPlus: true,
 				},
 			},
 			expected: false,
@@ -297,8 +292,7 @@ func TestHasDifferentArguments(t *testing.T) {
 					Namespace: namespace,
 				},
 				Spec: k8sv1alpha1.NginxIngressControllerSpec{
-					NginxPlus:  true,
-					EnableCRDs: true,
+					NginxPlus: true,
 				},
 			},
 			expected: true,
@@ -319,7 +313,6 @@ func TestHasDifferentArguments(t *testing.T) {
 				Spec: k8sv1alpha1.NginxIngressControllerSpec{
 					NginxPlus:     true,
 					DefaultSecret: "my-namespace/my-secret",
-					EnableCRDs:    true,
 				},
 			},
 			expected: true,


### PR DESCRIPTION
### Proposed changes
As described in the table https://github.com/nginxinc/nginx-ingress-operator/blob/master/docs/nginx-ingress-controller.md - the default value for enableCRDs if unset is `true` which is aligned with the behaviour of the Ingress Controller itself. 

* This PR ensures that if the field is unset that no arg related to `enableCRDs` is generated so the Ingress Controller default of `true` applies.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork