### PR TITLE
Update CRDs and RBAC for KIC 1.11

### DIFF
--- a/build/kic_crds/k8s.nginx.org_globalconfigurations.yaml
+++ b/build/kic_crds/k8s.nginx.org_globalconfigurations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: globalconfigurations.k8s.nginx.org
 spec:

--- a/build/kic_crds/k8s.nginx.org_policies.yaml
+++ b/build/kic_crds/k8s.nginx.org_policies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: policies.k8s.nginx.org
 spec:
@@ -16,7 +16,15 @@ spec:
     singular: policy
   scope: Namespaced
   versions:
-    - name: v1
+    - additionalPrinterColumns:
+        - description: Current state of the Policy. If the resource has a valid status, it means it has been validated and accepted by the Ingress Controller.
+          jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
       schema:
         openAPIV3Schema:
           description: Policy defines a Policy for VirtualServer and VirtualServerRoute resources.
@@ -128,8 +136,38 @@ spec:
                       type: integer
                     zoneSize:
                       type: string
+                waf:
+                  description: 'WAF defines an WAF policy. policy status: preview'
+                  type: object
+                  properties:
+                    apPolicy:
+                      type: string
+                    enable:
+                      type: boolean
+                    securityLog:
+                      description: SecurityLog defines the security log of a WAF policy.
+                      type: object
+                      properties:
+                        apLogConf:
+                          type: string
+                        enable:
+                          type: boolean
+                        logDest:
+                          type: string
+            status:
+              description: PolicyStatus is the status of the policy resource
+              type: object
+              properties:
+                message:
+                  type: string
+                reason:
+                  type: string
+                state:
+                  type: string
       served: true
       storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/build/kic_crds/k8s.nginx.org_transportservers.yaml
+++ b/build/kic_crds/k8s.nginx.org_transportservers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: transportservers.k8s.nginx.org
 spec:
@@ -16,7 +16,18 @@ spec:
     singular: transportserver
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - additionalPrinterColumns:
+        - description: Current state of the TransportServer. If the resource has a valid status, it means it has been validated and accepted by the Ingress Controller.
+          jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
       schema:
         openAPIV3Schema:
           description: TransportServer defines the TransportServer resource.
@@ -42,6 +53,8 @@ spec:
                       type: string
                 host:
                   type: string
+                ingressClassName:
+                  type: string
                 listener:
                   description: TransportServerListener defines a listener for a TransportServer.
                   type: object
@@ -50,10 +63,26 @@ spec:
                       type: string
                     protocol:
                       type: string
+                serverSnippets:
+                  type: string
+                sessionParameters:
+                  description: SessionParameters defines session parameters.
+                  type: object
+                  properties:
+                    timeout:
+                      type: string
                 upstreamParameters:
                   description: UpstreamParameters defines parameters for an upstream.
                   type: object
                   properties:
+                    connectTimeout:
+                      type: string
+                    nextUpstream:
+                      type: boolean
+                    nextUpstreamTimeout:
+                      type: string
+                    nextUpstreamTries:
+                      type: integer
                     udpRequests:
                       type: integer
                     udpResponses:
@@ -64,14 +93,48 @@ spec:
                     description: Upstream defines an upstream.
                     type: object
                     properties:
+                      failTimeout:
+                        type: string
+                      healthCheck:
+                        description: HealthCheck defines the parameters for active Upstream HealthChecks.
+                        type: object
+                        properties:
+                          enable:
+                            type: boolean
+                          fails:
+                            type: integer
+                          interval:
+                            type: string
+                          jitter:
+                            type: string
+                          passes:
+                            type: integer
+                          port:
+                            type: integer
+                          timeout:
+                            type: string
+                      maxFails:
+                        type: integer
                       name:
                         type: string
                       port:
                         type: integer
                       service:
                         type: string
+            status:
+              description: TransportServerStatus defines the status for the TransportServer resource.
+              type: object
+              properties:
+                message:
+                  type: string
+                reason:
+                  type: string
+                state:
+                  type: string
       served: true
       storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/build/kic_crds/k8s.nginx.org_virtualserverroutes.yaml
+++ b/build/kic_crds/k8s.nginx.org_virtualserverroutes.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: virtualserverroutes.k8s.nginx.org
 spec:
@@ -585,6 +585,8 @@ spec:
                         properties:
                           enable:
                             type: boolean
+                      use-cluster-ip:
+                        type: boolean
             status:
               description: VirtualServerRouteStatus defines the status for the VirtualServerRoute resource.
               type: object

--- a/build/kic_crds/k8s.nginx.org_virtualservers.yaml
+++ b/build/kic_crds/k8s.nginx.org_virtualservers.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: virtualservers.k8s.nginx.org
 spec:
@@ -615,6 +615,8 @@ spec:
                         properties:
                           enable:
                             type: boolean
+                      use-cluster-ip:
+                        type: boolean
             status:
               description: VirtualServerStatus defines the status for the VirtualServer resource.
               type: object

--- a/examples/deployment-oss-min/nginx-ingress-controller.yaml
+++ b/examples/deployment-oss-min/nginx-ingress-controller.yaml
@@ -12,3 +12,4 @@ spec:
     pullPolicy: Always
   replicas: 1
   serviceType: NodePort
+  

--- a/pkg/controller/nginxingresscontroller/rbac.go
+++ b/pkg/controller/nginxingresscontroller/rbac.go
@@ -55,7 +55,7 @@ func clusterRoleForNginxIngressController(name string) *rbacv1.ClusterRole {
 		{
 			Verbs:     []string{"update"},
 			APIGroups: []string{"k8s.nginx.org"},
-			Resources: []string{"virtualservers/status", "virtualserverroutes/status"},
+			Resources: []string{"virtualservers/status", "virtualserverroutes/status", "policies/status", "transportservers/status"},
 		},
 		{
 			Verbs:     []string{"get", "list", "watch"},

--- a/pkg/controller/nginxingresscontroller/rbac_test.go
+++ b/pkg/controller/nginxingresscontroller/rbac_test.go
@@ -63,7 +63,7 @@ func TestClusterRoleForNginxIngressController(t *testing.T) {
 			{
 				Verbs:     []string{"update"},
 				APIGroups: []string{"k8s.nginx.org"},
-				Resources: []string{"virtualservers/status", "virtualserverroutes/status"},
+				Resources: []string{"virtualservers/status", "virtualserverroutes/status", "policies/status", "transportservers/status"},
 			},
 			{
 				Verbs:     []string{"get", "list", "watch"},


### PR DESCRIPTION
### Proposed changes
Update CRDs and RBAC for KIC 1.11. Support added for:
- Policy status field
- Service IP as load balancing target
- Transport server snippets
- Transport server health checks
- Transport server configurable timeouts
- Transport server ingress class

Also updated CRDs with controller-tools 0.5.0 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [CONTRIBUTING](https://github.com/nginxinc/nginx-ingress-operator/blob/master/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the master branch and pulling from my branch from my own fork