### PR TITLE
Fix leader election for IC pods

### DIFF
--- a/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
+++ b/deploy/crds/k8s.nginx.org_nginxingresscontrollers_crd.yaml
@@ -72,7 +72,8 @@ spec:
             enableLeaderElection:
               description: Enables Leader election to avoid multiple replicas of the
                 controller reporting the status of Ingress resources – only one replica
-                will report status.
+                will report status. Default is true.
+              nullable: true
               type: boolean
             enablePreviewPolicies:
               description: Enables preview policies. Requires enableCRDs set to true.

--- a/docs/nginx-ingress-controller.md
+++ b/docs/nginx-ingress-controller.md
@@ -95,7 +95,7 @@ spec:
 | `logLevel` | `int` | Log level for V logs. Format is `0 - 3` | No |
 | `nginxStatus` | [nginxStatus](#nginxingresscontrollernginxstatus) | Configures NGINX stub_status, or the NGINX Plus API. | No |
 | `reportIngressStatus` | [reportIngressStatus](#nginxingresscontrollerreportingressstatus) | Update the address field in the status of Ingresses resources. | No |
-| `enableLeaderElection` | `boolean` | Enables Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources – only one replica will report status. | No |
+| `enableLeaderElection` | `boolean` | Enables Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources – only one replica will report status. Default is `true`. | No |
 | `wildcardTLS` | `string` | A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified. The secret must be of the type kubernetes.io/tls. If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection. If the argument is set, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress Controller will fail to start. Format is `namespace/name`. | No |
 | `prometheus` | [prometheus](#nginxingresscontrollerprometheus) | Configures NGINX or NGINX Plus metrics in the Prometheus format. | No |
 | `configMapData` | `map[string]string` | Initial values of the Ingress Controller ConfigMap. Check the [ConfigMap docs](https://docs.nginx.com/nginx-ingress-controller/configuration/global-configuration/configmap-resource/) for more information about possible values. | No |

--- a/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
+++ b/pkg/apis/k8s/v1alpha1/nginxingresscontroller_types.go
@@ -97,9 +97,11 @@ type NginxIngressControllerSpec struct {
 	ReportIngressStatus *ReportIngressStatus `json:"reportIngressStatus,omitempty"`
 	// Enables Leader election to avoid multiple replicas of the controller reporting the status of Ingress resources
 	// – only one replica will report status.
+	// Default is true.
 	// +kubebuilder:validation:Optional
+	// +nullable
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
-	EnableLeaderElection bool `json:"enableLeaderElection"`
+	EnableLeaderElection *bool `json:"enableLeaderElection"`
 	// A Secret with a TLS certificate and key for TLS termination of every Ingress host for which TLS termination is enabled but the Secret is not specified.
 	// The secret must be of the type kubernetes.io/tls.
 	// If the argument is not set, for such Ingress hosts NGINX will break any attempt to establish a TLS connection.

--- a/pkg/apis/k8s/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/k8s/v1alpha1/zz_generated.deepcopy.go
@@ -151,6 +151,11 @@ func (in *NginxIngressControllerSpec) DeepCopyInto(out *NginxIngressControllerSp
 		*out = new(ReportIngressStatus)
 		**out = **in
 	}
+	if in.EnableLeaderElection != nil {
+		in, out := &in.EnableLeaderElection, &out.EnableLeaderElection
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Prometheus != nil {
 		in, out := &in.Prometheus, &out.Prometheus
 		*out = new(Prometheus)

--- a/pkg/controller/nginxingresscontroller/utils.go
+++ b/pkg/controller/nginxingresscontroller/utils.go
@@ -91,8 +91,10 @@ func generatePodArgs(instance *k8sv1alpha1.NginxIngressController) []string {
 		}
 	}
 
-	if instance.Spec.EnableLeaderElection {
-		args = append(args, "-enable-leader-election")
+	if instance.Spec.EnableLeaderElection == nil || *instance.Spec.EnableLeaderElection {
+		args = append(args, fmt.Sprintf("-leader-election-lock-name=%v-lock", instance.Name))
+	} else {
+		args = append(args, "-enable-leader-election=false")
 	}
 
 	if instance.Spec.WildcardTLS != "" {


### PR DESCRIPTION
### Proposed changes

- The operator now configures the leader-election-lock-name cli
argument of the IC with the value based on the name of the
NginxIngressController resource. This allows deploying multiple
ICs in the same namespace.
- The documentation and type of the spec.EnableLeaderElection is
updated: it is now a pointer with the default value 'true'. This
matches the default value of the corresponding IC cli argument.
The previous behavior was also incorrect - the operator would always
enable the leader election, no matter the value of
spec.EnableLeaderElection.

Fixes https://github.com/nginxinc/nginx-ingress-operator/issues/87