### PR TITLE
Add revive linter with recommended config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,33 @@
 linters-settings:
   misspell:
     locale: US
+  revive:
+    ignore-generated-header: true
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
 
 linters:
     enable:
@@ -20,6 +47,7 @@ linters:
     - nilerr
     - noctx
     - predeclared
+    - revive
     - staticcheck
     - structcheck
     - typecheck

--- a/controllers/nginxingresscontroller_controller.go
+++ b/controllers/nginxingresscontroller_controller.go
@@ -255,13 +255,13 @@ func (r *NginxIngressControllerReconciler) Reconcile(ctx context.Context, req ct
 }
 
 // createIfNotExists creates a new object. If the object exists, does nothing. It returns whether the object existed before or not.
-func (r *NginxIngressControllerReconciler) createIfNotExists(object client.Object) (error, bool) {
+func (r *NginxIngressControllerReconciler) createIfNotExists(object client.Object) (bool, error) {
 	err := r.Create(context.TODO(), object)
 	if err != nil && errors.IsAlreadyExists(err) {
-		return nil, true
+		return true, nil
 	}
 
-	return err, false
+	return false, err
 }
 
 func (r *NginxIngressControllerReconciler) finalizeNginxIngressController(log logr.Logger, instance *k8sv1alpha1.NginxIngressController) error {

--- a/controllers/prerequisites.go
+++ b/controllers/prerequisites.go
@@ -18,7 +18,7 @@ func (r *NginxIngressControllerReconciler) checkPrerequisites(log logr.Logger, i
 	if err != nil {
 		return err
 	}
-	err, existed := r.createIfNotExists(sa)
+	existed, err := r.createIfNotExists(sa)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (r *NginxIngressControllerReconciler) checkPrerequisites(log logr.Logger, i
 		}
 		ic := ingressClassForNginxIngressController(instance)
 
-		err, existed = r.createIfNotExists(ic)
+		existed, err = r.createIfNotExists(ic)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Adding `revive` (replacement for the deprecated `golint`) with the [recommended](https://github.com/mgechev/revive#recommended-configuration) configuration