### PR TITLE
Make spec.Prometheus.secret field optional

### DIFF
--- a/api/v1alpha1/nginxingresscontroller_types.go
+++ b/api/v1alpha1/nginxingresscontroller_types.go
@@ -263,7 +263,12 @@ type Prometheus struct {
 	// +kubebuilder:validation:Optional
 	// +nullable
 	Port *uint16 `json:"port"`
-	// Specifies an TLS Secret in the format namespace/name to use to secure the Prometheus endpoint.
+	// A Secret with a TLS certificate and key for TLS termination of the Prometheus endpoint.
+	// The secret must be of the type kubernetes.io/tls.
+	// If specified, but the Ingress controller is not able to fetch the Secret from Kubernetes API,
+	// the Ingress Controller will fail to start.
+	// Format is namespace/name.
+	// +kubebuilder:validation:Optional
 	Secret string `json:"secret"`
 }
 

--- a/config/crd/bases/k8s.nginx.org_nginxingresscontrollers.yaml
+++ b/config/crd/bases/k8s.nginx.org_nginxingresscontrollers.yaml
@@ -198,12 +198,14 @@ spec:
                     nullable: true
                     type: integer
                   secret:
-                    description: Specifies an TLS Secret in the format namespace/name
-                      to use to secure the Prometheus endpoint.
+                    description: A Secret with a TLS certificate and key for TLS termination
+                      of the Prometheus endpoint. The secret must be of the type kubernetes.io/tls.
+                      If specified, but the Ingress controller is not able to fetch
+                      the Secret from Kubernetes API, the Ingress Controller will
+                      fail to start. Format is namespace/name.
                     type: string
                 required:
                 - enable
-                - secret
                 type: object
               replicas:
                 description: The number of replicas of the Ingress Controller pod.

--- a/docs/nginx-ingress-controller.md
+++ b/docs/nginx-ingress-controller.md
@@ -148,7 +148,7 @@ spec:
 | --- | --- | --- | --- |
 | `enable` | `boolean` | Enable Prometheus metrics. | Yes |
 | `port` | `int` | Sets the port where the Prometheus metrics are exposed. Default is 9113. Format is `1023 - 65535`. | No |
-| `secret` | `string` | Sets the namespace/name of a TLS Secret Resource to use to enable TLS for the Prometheus endpoint. | No |
+| `secret` | `string` | A Secret with a TLS certificate and key for TLS termination of the Prometheus endpoint. The secret must be of the type kubernetes.io/tls. If specified, but the Ingress controller is not able to fetch the Secret from Kubernetes API, the Ingress Controller will fail to start. Format is namespace/name. | No |
 | `enableLatencyMetrics` | `boolean` | Bucketed response times from when NGINX establishes a connection to an upstream server to when the last byte of the response body is received by NGINX. **Note** The metric for the upstream isn't available until traffic is sent to the upstream. Requires prometheus set to true | No |
 
 ## NginxIngressController.AppProtect


### PR DESCRIPTION
- Make the spec.Prometheus.secret optional so that Prometheus endpoint
can be enabled without specifying a Secret.
- Extend the doc for the field.

If the field is not mark as optional, the admin will incorrectly see the following error:
```
kubectl apply -f ic.yaml
The NginxIngressController "my-nginx-ingress-controller" is invalid: spec.prometheus.secret: Required value
```
For ic.yaml:
```yaml
apiVersion: k8s.nginx.org/v1alpha1
kind: NginxIngressController
metadata:
  name: my-nginx-ingress-controller
spec:
  type: deployment
  image:
    repository: nginx/nginx-ingress
    tag: 1.12.0
    pullPolicy: Always
  serviceType: NodePort
  prometheus:
    enable: true
```