### PR TITLE
Add missing metadata in the bundle, helper script for certification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY LICENSE /licenses/
 LABEL name="NGINX Ingress Operator" \
       maintainer="kubernetes@nginx.com" \
       vendor="NGINX Inc" \
-      version="v${VERSION}" \
+      version="${VERSION}" \
       release="1" \
       summary="The NGINX Ingress Operator is a Kubernetes/OpenShift component which deploys and manages one or more NGINX/NGINX Plus Ingress Controllers" \
       description="The NGINX Ingress Operator is a Kubernetes/OpenShift component which deploys and manages one or more NGINX/NGINX Plus Ingress Controllers"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,6 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=nginx-ingress-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.15.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
@@ -19,6 +20,6 @@ COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
 
-LABEL com.redhat.openshift.versions="v4.5"
+LABEL com.redhat.openshift.versions="v4.6"
 LABEL com.redhat.delivery.operator.bundle=true
 LABEL com.redhat.delivery.backport=true

--- a/bundle/manifests/nginx-ingress-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/nginx-ingress-operator.clusterserviceversion.yaml
@@ -27,12 +27,17 @@ metadata:
     categories: Monitoring, Networking
     certified: "true"
     containerImage: nginx/nginx-ingress-operator:0.5.0
+    createdAt: placeholder
     description: The NGINX Ingress Operator is a Kubernetes/OpenShift component which
       deploys and manages one or more NGINX/NGINX Plus Ingress Controllers
     operators.operatorframework.io/builder: operator-sdk-v1.15.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/nginxinc/nginx-ingress-operator
     support: NGINX Inc.
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: nginx-ingress-operator.v0.5.0
   namespace: placeholder
 spec:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,6 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: nginx-ingress-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.15.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
@@ -12,3 +13,6 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # OpenShift annotations.
+  com.redhat.openshift.versions: v4.6

--- a/config/manifests/bases/nginx-ingress-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/nginx-ingress-operator.clusterserviceversion.yaml
@@ -7,10 +7,15 @@ metadata:
     categories: Monitoring, Networking
     certified: "true"
     containerImage: nginx/nginx-ingress-operator:0.5.0
+    createdAt: placeholder
     description: The NGINX Ingress Operator is a Kubernetes/OpenShift component which
       deploys and manages one or more NGINX/NGINX Plus Ingress Controllers
     repository: https://github.com/nginxinc/nginx-ingress-operator
     support: NGINX Inc.
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   name: nginx-ingress-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/hack/get_image_info.sh
+++ b/hack/get_image_info.sh
@@ -25,5 +25,5 @@ kube_digest=$(curl -sSfL -I -H "Accept: application/vnd.docker.distribution.mani
 printf "%s\n\n" "Manually repleace the following values in bundle/manifests/nginx-ingress-operator.clusterserviceversion.yaml"
 printf "%s\n" "metadata.annotations.createdAt: ${created}"
 printf "%s\n" "metadata.annotations.containerImage: docker.io/${image}@${image_digest}"
-printf "%s\n" ".spec.install.spec.deployments[0].spec.template.spec.containers[1].image (nginx-ingress-operator): docker.io/${image}@${image_digest}"
-printf "%s\n" ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image (kube-rbac-proxy): ${full_image}@${kube_digest}"
+printf "%s\n" "spec.install.spec.deployments[0].spec.template.spec.containers[1].image (nginx-ingress-operator): docker.io/${image}@${image_digest}"
+printf "%s\n" "spec.install.spec.deployments[0].spec.template.spec.containers[0].image (kube-rbac-proxy): ${full_image}@${kube_digest}"

--- a/hack/get_image_info.sh
+++ b/hack/get_image_info.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+image=$1
+version=$2
+
+kube_image=kubebuilder/kube-rbac-proxy
+kube_image_version=v0.8.0
+
+token="$(curl 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:'${image}':pull' 2>/dev/null | jq -r '.token')"
+
+image_digest=$(curl -sSfL -I -H "Authorization: Bearer ${token}" -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" "https://index.docker.io/v2/${image}/manifests/${version}" | awk 'BEGIN {FS=": "}/^docker-content-digest/{gsub(/"/, "", $2); print $2}')
+
+digest="$(curl -sSfL -H "Authorization: Bearer ${token}" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "https://index.docker.io/v2/${image}/manifests/${version}" | jq -r '.config.digest')"
+
+created=$(curl -sSfL -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -H "Authorization: Bearer ${token}" "https://index.docker.io/v2/${image}/blobs/${digest}" | jq -r '.config.Labels."org.opencontainers.image.created"')
+
+proxy="./config/default/manager_auth_proxy_patch.yaml"
+kube_proxy=$(yq e '.spec.template.spec.containers.[0].image' $proxy)
+full_image=${kube_proxy%:*}
+kube_image=${full_image#*/}
+kube_version=${kube_proxy#*:}
+
+kube_digest=$(curl -sSfL -I -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" "https://gcr.io/v2/${kube_image}/manifests/${kube_version}" | awk 'BEGIN {FS=": "}/^docker-content-digest/{gsub(/"/, "", $2); print $2}')
+
+printf "%s\n\n" "Manually repleace the following values in bundle/manifests/nginx-ingress-operator.clusterserviceversion.yaml"
+printf "%s\n" "metadata.annotations.createdAt: ${created}"
+printf "%s\n" "metadata.annotations.containerImage: docker.io/${image}@${image_digest}"
+printf "%s\n" ".spec.install.spec.deployments[0].spec.template.spec.containers[1].image (nginx-ingress-operator): docker.io/${image}@${image_digest}"
+printf "%s\n" ".spec.install.spec.deployments[0].spec.template.spec.containers[0].image (kube-rbac-proxy): ${full_image}@${kube_digest}"


### PR DESCRIPTION
- Adds metadata in the bundle required for Red Hat certification
- Adds helper script that retrieves SHA for the docker images (needed for the certification). The images need to have the SHA instead of a tag, and the creation date of the Operator container.

Ideally, we could have the script fill out the fields with the required data, but `yq` has a bug that changes all the formatting of the yaml file https://github.com/mikefarah/yq#known-issues--missing-features